### PR TITLE
fix autotools deprecation warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 
 AC_PREREQ(2.59)
 AC_INIT(dymo-cups-drivers, 1.4.0.5, vbuzuev@dymo.com)
-AM_INIT_AUTOMAKE(dymo-cups-drivers, 1.4.0.5)
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([src/lw/CupsFilterLabelWriter.h])
 AC_CONFIG_HEADER([src/config.h])
 

--- a/ppd/Makefile.am
+++ b/ppd/Makefile.am
@@ -50,5 +50,5 @@ check_PROGRAMS = testppd
 
 testppd_SOURCES=
 
-testppd:
+testppd$(EXEEXT):
 	cupstestppd $(dist_cupsmodel_DATA)

--- a/samples/custom_paper/Makefile.am
+++ b/samples/custom_paper/Makefile.am
@@ -25,7 +25,7 @@ CustomPaper_SOURCES = \
 
 CustomPaper_LDADD = $(CUPS_LIBS) -lcairo
 
-INCLUDES = -I/usr/include/cairo
+AM_CPPFLAGS = -I/usr/include/cairo
 
 if SAMPLES
      SAMPLE_PROGS = CustomPaper

--- a/samples/custom_paper_tape/Makefile.am
+++ b/samples/custom_paper_tape/Makefile.am
@@ -25,7 +25,7 @@ CustomPaperTape_SOURCES = \
 
 CustomPaperTape_LDADD = $(CUPS_LIBS) -lcairo
 
-INCLUDES = -I/usr/include/cairo
+AM_CPPFLAGS = -I/usr/include/cairo
 
 if SAMPLES
      SAMPLE_PROGS = CustomPaperTape

--- a/samples/paper_bounds/Makefile.am
+++ b/samples/paper_bounds/Makefile.am
@@ -25,7 +25,7 @@ PaperBounds_SOURCES = \
 
 PaperBounds_LDADD = $(CUPS_LIBS) -lcairo
 
-INCLUDES = -I/usr/include/cairo
+AM_CPPFLAGS = -I/usr/include/cairo
 
 if SAMPLES
      SAMPLE_PROGS = PaperBounds

--- a/samples/test_label/Makefile.am
+++ b/samples/test_label/Makefile.am
@@ -27,7 +27,7 @@ TestLabel_LDADD = $(CUPS_LIBS) -lcairo
 
 EXTRA_DIST = tel.png photo.png barcode.png
 
-INCLUDES = -I/usr/include/cairo
+AM_CPPFLAGS = -I/usr/include/cairo
 
 if SAMPLES
      SAMPLE_PROGS = TestLabel

--- a/src/common/tests/Makefile.am
+++ b/src/common/tests/Makefile.am
@@ -38,7 +38,7 @@ tests_SOURCES = \
     
 tests_LDADD = $(CUPS_LIBS) -lcppunit -ldl
 
-INCLUDES = -I.. -I.
+AM_CPPFLAGS = -I.. -I.
 
 #
 #  End of $Id: Makefile.am 4759 2008-06-19 19:02:27Z vbuzuev $

--- a/src/lm/Makefile.am
+++ b/src/lm/Makefile.am
@@ -19,7 +19,7 @@
 
 SUBDIRS = tests
 
-INCLUDES = -I../common
+AM_CPPFLAGS = -I../common
 
 cupsfilter_PROGRAMS = raster2dymolm
 

--- a/src/lm/tests/Makefile.am
+++ b/src/lm/tests/Makefile.am
@@ -41,7 +41,7 @@ tests_SOURCES = \
     
 tests_LDADD = $(CUPS_LIBS) -lcppunit -ldl
 
-INCLUDES = -I../../common -I../../common/tests
+AM_CPPFLAGS = -I../../common -I../../common/tests
 
 #
 #  End of $Id: Makefile.am 15968 2011-09-02 14:56:33Z pineichen $

--- a/src/lw/Makefile.am
+++ b/src/lw/Makefile.am
@@ -45,7 +45,7 @@ raster2dymolw_SOURCES = \
     
 raster2dymolw_LDADD = $(CUPS_LIBS)
 
-INCLUDES = -I../common
+AM_CPPFLAGS = -I../common
 
 #
 #  End of $Id: Makefile.am 4759 2008-06-19 19:02:27Z vbuzuev $

--- a/src/lw/tests/Makefile.am
+++ b/src/lw/tests/Makefile.am
@@ -46,7 +46,7 @@ tests_SOURCES = \
     
 tests_LDADD = $(CUPS_LIBS) -lcppunit -ldl
 
-INCLUDES = -I../../common -I../../common/tests
+AM_CPPFLAGS = -I../../common -I../../common/tests
 
 #
 #  End of $Id: Makefile.am 4759 2008-06-19 19:02:27Z vbuzuev $


### PR DESCRIPTION
There are several warnings generated by autotools during the build process. Here is a portion of the output:
```
configure.ac:22: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.
ppd/Makefile.am:53: warning: deprecated feature: target 'testppd' overrides 'testppd$(EXEEXT)'
src/lm/Makefile.am:22: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
src/lm/Makefile.am:26: warning: source file '../common/CupsPrintEnvironment.cpp' is in a subdirectory,
src/lm/Makefile.am:26: but option 'subdir-objects' is disabled
src/lm/Makefile.am:26: warning: source file '../common/Halftoning.cpp' is in a subdirectory,
src/lm/Makefile.am:26: but option 'subdir-objects' is disabled
src/lm/Makefile.am:26: warning: source file '../common/ErrorDiffusionHalftoning.cpp' is in a subdirectory,
src/lm/Makefile.am:26: but option 'subdir-objects' is disabled
src/lm/Makefile.am:26: warning: source file '../common/NonLinearLaplacianHalftoning.cpp' is in a subdirectory,
src/lm/Makefile.am:26: but option 'subdir-objects' is disabled
```

This PR fixes all of these warnings. This patch has been tested to build successfully on Fedora 29 and El7. 